### PR TITLE
Revert to treating exclude in .ini as single string

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -197,18 +197,19 @@ section of the command line docs.
 
 .. confval:: exclude
 
-    :type: newline separated list of regular expressions
+    :type: regular expressions
 
-    A newline list of regular expression that matches file names, directory names and paths
+    A regular expression that matches file names, directory names and paths
     which mypy should ignore while recursively discovering files to check.
     Use forward slashes on all platforms.
 
     .. code-block:: ini
 
       [mypy]
-      exclude =
+      exclude = (?x)(
           ^file1\.py$
-          ^file2\.py$
+          |^file2\.py$
+        )
 
     For more details, see :option:`--exclude <mypy --exclude>`.
 
@@ -997,8 +998,8 @@ of your repo (or append it to the end of an existing ``pyproject.toml`` file) an
     warn_return_any = true
     warn_unused_configs = true
     exclude = [
-        '^file1\.py$',  # TOML single-quoted string (no escaping necessary)
-        "^file2\\.py$",  # TOML double-quoted string (backslash needs escaping)
+        '^file1\.py$',  # TOML literal string (single quotes, no escaping necessary)
+        "^file2\\.py$",  # TOML basic string (double quotes, backslash and other characters need escaping)
     ]
 
     # mypy per-module options:

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -132,7 +132,7 @@ ini_config_types: Final[Dict[str, _INI_PARSER_CALLABLE]] = {
     'cache_dir': expand_path,
     'python_executable': expand_path,
     'strict': bool,
-    'exclude': lambda s: [p.strip() for p in s.split('\n') if p.strip()],
+    'exclude': lambda s: [s.strip()],
 }
 
 # Reuse the ini_config_types and overwrite the diff

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1354,9 +1354,10 @@ b/bpkg.py:1: error: "int" not callable
 # cmd: mypy .
 [file mypy.ini]
 \[mypy]
-exclude =
-    abc
-    b
+exclude = (?x)(
+    ^abc/
+    |^b/
+  )
 [file abc/apkg.py]
 1()
 [file b/bpkg.py]


### PR DESCRIPTION
Includes additional unit tests.

Fixes #11830. Depends on #11828.
